### PR TITLE
DIRSTUDIO-1287 Bump mina from 2.1.3 to 2.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
     <org.apache.directory.api.version>2.1.0</org.apache.directory.api.version>
     <org.apache.directory.api.bundleversion>2.1.0</org.apache.directory.api.bundleversion>
     <org.apache.directory.server.version>2.0.0.AM26</org.apache.directory.server.version>
-    <org.apache.mina.version>2.1.3</org.apache.mina.version>
-    <org.apache.mina.bundleversion>2.1.3</org.apache.mina.bundleversion>
+    <org.apache.mina.version>2.1.10</org.apache.mina.version>
+    <org.apache.mina.bundleversion>2.1.10</org.apache.mina.bundleversion>
     <org.apache.poi.version>5.2.5</org.apache.poi.version>
     <org.apache.poi.bundleversion>5.2.5</org.apache.poi.bundleversion>
     <org.apache.xmlgraphics.fop.version>2.9</org.apache.xmlgraphics.fop.version>


### PR DESCRIPTION
With mina 2.1.3 connections to TLS 1.3 enabled servers fail with `ERR_04169_RESPONSE_QUEUE_EMPTIED`. See
- https://issues.apache.org/jira/browse/DIRSTUDIO-1287
- https://issues.apache.org/jira/browse/DIRAPI-381